### PR TITLE
Implement retry logic for standings API fetch and update UCL tab state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.env

--- a/src/HomePage.jsx
+++ b/src/HomePage.jsx
@@ -14,7 +14,7 @@ import {
 
 export default function FutbolStats() {
   const [leagueActiveTab, setLeagueActiveTab] = useState("laliga");
-  const [uclActiveTab, setUclActiveTab] = useState("uclGroupA");
+  const [uclActiveTab, setUclActiveTab] = useState("cl");
   const [loading, setLoading] = useState(true);
   const [stats, setStats] = useState([]);
   const [leagueData, setLeagueData] = useState({
@@ -22,10 +22,7 @@ export default function FutbolStats() {
     premier: [],
     seriea: [],
     bundesliga: [],
-    uclGroupA: [],
-    uclGroupB: [],
-    uclGroupC: [],
-    uclGroupD: [],
+    cl: [],
   });
   const [topPlayers, setTopPlayers] = useState([]);
   const [liveMatches, setLiveMatches] = useState([]);
@@ -436,50 +433,6 @@ export default function FutbolStats() {
             <h2 className="text-white text-3xl font-bold text-center mb-10">
               Clasificación - UEFA Champions League
             </h2>
-
-            <div className="mb-6 flex flex-wrap justify-center gap-2">
-              <button
-                onClick={() => setUclActiveTab("uclGroupA")}
-                className={`px-4 py-2 rounded-full text-sm font-medium transition-all ${
-                  uclActiveTab === "uclGroupA"
-                    ? "bg-blue-600 text-blue"
-                    : "bg-gray-200 text-gray-700 hover:bg-gray-300"
-                }`}
-              >
-                Grupo A
-              </button>
-              <button
-                onClick={() => setUclActiveTab("uclGroupB")}
-                className={`px-4 py-2 rounded-full text-sm font-medium transition-all ${
-                  uclActiveTab === "uclGroupB"
-                    ? "bg-blue-600 text-blue"
-                    : "bg-gray-200 text-gray-700 hover:bg-gray-300"
-                }`}
-              >
-                Grupo B
-              </button>
-              <button
-                onClick={() => setUclActiveTab("uclGroupC")}
-                className={`px-4 py-2 rounded-full text-sm font-medium transition-all ${
-                  uclActiveTab === "uclGroupC"
-                    ? "bg-blue-600 text-blue"
-                    : "bg-gray-200 text-gray-700 hover:bg-gray-300"
-                }`}
-              >
-                Grupo C
-              </button>
-              <button
-                onClick={() => setUclActiveTab("uclGroupD")}
-                className={`px-4 py-2 rounded-full text-sm font-medium transition-all ${
-                  uclActiveTab === "uclGroupD"
-                    ? "bg-blue-600 text-blue"
-                    : "bg-gray-200 text-gray-700 hover:bg-gray-300"
-                }`}
-              >
-                Grupo D
-              </button>
-            </div>
-
             <div className="bg-white rounded-xl shadow-md overflow-hidden">
               <div className="overflow-x-auto">
                 <table className="min-w-full">


### PR DESCRIPTION
This pull request includes several changes to improve the handling of API requests, update the data structure for league standings, and simplify the UI for displaying UEFA Champions League standings as per the new format.

### Improvements to API request handling:

* Added a `fetchWithRetry` function to handle retries with **exponential backoff** for rate-limited API requests in `server/index.js`.

### Updates to data structure:

* Updated the league IDs in the `leagues` object to include the Champions League (`cl`) in `server/index.js`.
* Changed the initial state and structure of `leagueData` to use a single key for the Champions League (`cl`) in `src/HomePage.jsx`.

### UI simplification:

* Removed the buttons for selecting individual UEFA Champions League groups from the UI in `src/HomePage.jsx` as they are no longer needed.